### PR TITLE
Add basic gamification with points and ranking

### DIFF
--- a/taverna/models.py
+++ b/taverna/models.py
@@ -15,6 +15,7 @@ class Usuario(database.Model, UserMixin):
     senha = database.Column(database.String, nullable=False)
 
     avatar = database.Column(database.String, default="avatar1.jpeg")  # <- novo campo
+    pontos = database.Column(database.Integer, default=0)
 
     # Relacionamentos
     projetos = database.relationship("Projeto", backref="autor", lazy=True)

--- a/taverna/routes.py
+++ b/taverna/routes.py
@@ -79,6 +79,12 @@ def criar_projeto(form_projeto, usuario_id):
             )
             database.session.add(midia)
     database.session.commit()
+
+    usuario = Usuario.query.get(usuario_id)
+    if usuario:
+        usuario.pontos = (usuario.pontos or 0) + 10
+        database.session.commit()
+
     return projeto
 
 # ---------------- Perfil com Upload de Projeto ----------------
@@ -138,6 +144,9 @@ def feed():
             id_midia=id_midia
         )
         database.session.add(novo_comentario)
+        usuario = Usuario.query.get(current_user.id)
+        if usuario:
+            usuario.pontos = (usuario.pontos or 0) + 2
         database.session.commit()
         return redirect(url_for("feed", tag=tag_filtro or None, categoria=categoria_filtro or None, ano=ano_filtro or None))
 
@@ -157,7 +166,8 @@ def feed():
 # ---------------- Rotas auxiliares ----------------
 @app.route("/taverna")
 def taverna():
-    return render_template("taverna.html")
+    ranking_usuarios = Usuario.query.order_by(Usuario.pontos.desc()).limit(5).all()
+    return render_template("taverna.html", ranking_usuarios=ranking_usuarios)
 
 @app.route("/missoes")
 def missoes():
@@ -187,12 +197,15 @@ def visualizar_projeto(id_projeto):
 
     if form_comentario.validate_on_submit():
         novo_comentario = ComentarioProjeto(
-    texto=form_comentario.texto.data,
-    id_usuario=current_user.id,
-    id_projeto=id_projeto
-)
+            texto=form_comentario.texto.data,
+            id_usuario=current_user.id,
+            id_projeto=id_projeto
+        )
 
         database.session.add(novo_comentario)
+        usuario = Usuario.query.get(current_user.id)
+        if usuario:
+            usuario.pontos = (usuario.pontos or 0) + 2
         database.session.commit()
         return redirect(url_for("visualizar_projeto", id_projeto=projeto.id))
 

--- a/taverna/templates/perfil.html
+++ b/taverna/templates/perfil.html
@@ -12,7 +12,10 @@ Perfil - {{ usuario.username }}
     <img src="{{ url_for('static', filename='avatares/' ~ usuario.avatar) }}"
          alt="Avatar do usuário"
          class="avatar-perfil">
-    <h1>Perfil do usuário: {{ usuario.username }}</h1>
+    <div>
+      <h1>Perfil do usuário: {{ usuario.username }}</h1>
+      <p>Pontos: {{ usuario.pontos }}</p>
+    </div>
   </div>
 
   <div class="conteudo">

--- a/taverna/templates/taverna.html
+++ b/taverna/templates/taverna.html
@@ -8,5 +8,15 @@ Bem vindo a taverna
 <body>
     <h1>Taverna</h1>
     <a href="{{url_for('homepage')}}">voltar</a>
+    <section class="ranking">
+        <h2>Ranking de Aventureiros</h2>
+        <ol>
+        {% for usuario in ranking_usuarios %}
+            <li>{{ usuario.username }} - {{ usuario.pontos }} pts</li>
+        {% else %}
+            <li>Nenhum usuário pontuado ainda.</li>
+        {% endfor %}
+        </ol>
+    </section>
 </body>
 {% endblock %}

--- a/upgrade_banco.py
+++ b/upgrade_banco.py
@@ -29,6 +29,8 @@ with app.app_context():
     colunas_usuario = [col['name'] for col in inspector.get_columns('usuario')]
     if 'avatar' not in colunas_usuario:
         database.session.execute(text("ALTER TABLE usuario ADD COLUMN avatar TEXT DEFAULT 'avatar1.jpeg'"))
+    if 'pontos' not in colunas_usuario:
+        database.session.execute(text("ALTER TABLE usuario ADD COLUMN pontos INTEGER DEFAULT 0"))
 
     database.session.commit()
     print("Banco verificado e atualizado com sucesso.")


### PR DESCRIPTION
## Summary
- track user points for actions like publishing projects or commenting
- add ranking of top users in the tavern page
- display current points on user profile and ensure database upgrade adds the new column

## Testing
- `python -m py_compile taverna/models.py upgrade_banco.py taverna/routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b24313e9dc83248a59d559e538a6c0