### PR TITLE
Add circular avatar health bar

### DIFF
--- a/taverna/static/css/style.css
+++ b/taverna/static/css/style.css
@@ -1278,6 +1278,26 @@ html, body {
   object-fit: cover;
   border: 3px solid #6c4ed2;
 }
+
+.avatar-life {
+  --progress: 0%;
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: conic-gradient(#6c4ed2 var(--progress), #ddd 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+}
+
+.avatar-life .avatar-perfil {
+  width: 100%;
+  height: 100%;
+  border: none;
+  margin: 0;
+}
 @keyframes fadeInUp {
   from {
     opacity: 0;

--- a/taverna/static/css/style2.css
+++ b/taverna/static/css/style2.css
@@ -1278,3 +1278,23 @@ html, body {
   object-fit: cover;
   border: 3px solid #6c4ed2;
 }
+
+.avatar-life {
+  --progress: 0%;
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: conic-gradient(#6c4ed2 var(--progress), #ddd 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px;
+}
+
+.avatar-life .avatar-perfil {
+  width: 100%;
+  height: 100%;
+  border: none;
+  margin: 0;
+}

--- a/taverna/templates/perfil.html
+++ b/taverna/templates/perfil.html
@@ -9,12 +9,13 @@ Perfil - {{ usuario.username }}
 
 <section class="container">
   <div class="bloco-add-img" style="display: flex; align-items: center; gap: 20px;">
-    <img src="{{ url_for('static', filename='avatares/' ~ usuario.avatar) }}"
-         alt="Avatar do usuário"
-         class="avatar-perfil">
+    <div class="avatar-life" style="--progress: {{ usuario.pontos|default(0) }}%;">
+      <img src="{{ url_for('static', filename='avatares/' ~ usuario.avatar) }}"
+           alt="Avatar do usuário"
+           class="avatar-perfil">
+    </div>
     <div>
       <h1>Perfil do usuário: {{ usuario.username }}</h1>
-      <p>Pontos: {{ usuario.pontos }}</p>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- wrap profile avatar with CSS-driven circular life bar
- remove numeric score display on profile
- add reusable avatar-life styles

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: upgrade_banco.py syntax error)*
- `python -m py_compile taverna/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b24caf2990832497f9399948827fdf