### PR TITLE
Add level badges and profile navigation

### DIFF
--- a/taverna/static/css/style.css
+++ b/taverna/static/css/style.css
@@ -1298,6 +1298,27 @@ html, body {
   border: none;
   margin: 0;
 }
+
+.badge-nivel {
+  background: #ffd700;
+  color: #333;
+  font-size: 12px;
+  font-weight: bold;
+  padding: 2px 6px;
+  border-radius: 12px;
+  margin-left: 5px;
+  display: inline-block;
+}
+
+.avatar-life .badge-nivel {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  transform: translate(50%, 50%);
+  margin-left: 0;
+  border-radius: 50%;
+  padding: 4px 6px;
+}
 @keyframes fadeInUp {
   from {
     opacity: 0;

--- a/taverna/templates/feed.html
+++ b/taverna/templates/feed.html
@@ -81,7 +81,10 @@ Feed da Taverna
       {% for projeto in projetos %}
         <div class="card-feed">
           <h2>{{ projeto.titulo }}</h2>
-          <p><strong>Autor:</strong> {{ projeto.autor.username }}</p>
+          <p><strong>Autor:</strong>
+            <a href="{{ url_for('perfil', id_usuario=projeto.autor.id) }}">{{ projeto.autor.username }}</a>
+            <span class="badge-nivel">Lv {{ niveis_autores[projeto.autor.id] }}</span>
+          </p>
           <p><strong>Descrição:</strong> {{ projeto.descricao }}</p>
 
           <div class="tags">

--- a/taverna/templates/perfil.html
+++ b/taverna/templates/perfil.html
@@ -9,10 +9,11 @@ Perfil - {{ usuario.username }}
 
 <section class="container">
   <div class="bloco-add-img" style="display: flex; align-items: center; gap: 20px;">
-    <div class="avatar-life" style="--progress: {{ usuario.pontos|default(0) }}%;">
+    <div class="avatar-life" style="--progress: {{ progresso }}%;">
       <img src="{{ url_for('static', filename='avatares/' ~ usuario.avatar) }}"
            alt="Avatar do usuário"
            class="avatar-perfil">
+      <span class="badge-nivel">Lv {{ nivel }}</span>
     </div>
     <div>
       <h1>Perfil do usuário: {{ usuario.username }}</h1>

--- a/taverna/templates/taverna.html
+++ b/taverna/templates/taverna.html
@@ -12,7 +12,11 @@ Bem vindo a taverna
         <h2>Ranking de Aventureiros</h2>
         <ol>
         {% for usuario in ranking_usuarios %}
-            <li>{{ usuario.username }} - {{ usuario.pontos }} pts</li>
+            <li>
+              <a href="{{ url_for('perfil', id_usuario=usuario.id) }}">{{ usuario.username }}</a>
+              <span class="badge-nivel">Lv {{ niveis[usuario.id] }}</span>
+              - {{ usuario.pontos }} pts
+            </li>
         {% else %}
             <li>Nenhum usuário pontuado ainda.</li>
         {% endfor %}

--- a/taverna/utils.py
+++ b/taverna/utils.py
@@ -36,3 +36,28 @@ def get_ranking_de_anos(limit=10):
             contador.update([ano.strip()])
 
     return contador.most_common(limit)
+
+
+def calcular_nivel(pontos):
+    """Calcula o nível do usuário e o progresso para o próximo nível.
+
+    A cada nível, a quantidade de experiência necessária aumenta
+    progressivamente. O primeiro nível requer 100 pontos, o segundo
+    requer 200, o terceiro 300 e assim por diante.
+
+    Retorna uma tupla (nivel, progresso), onde ``nivel`` é o nível
+    atual e ``progresso`` é a porcentagem (0-100) de experiência
+    acumulada no nível atual.
+    """
+
+    nivel = 1
+    pontos_restantes = pontos or 0
+    xp_necessaria = 100
+
+    while pontos_restantes >= xp_necessaria:
+        pontos_restantes -= xp_necessaria
+        nivel += 1
+        xp_necessaria = 100 * nivel
+
+    progresso = int((pontos_restantes / xp_necessaria) * 100) if xp_necessaria else 0
+    return nivel, progresso


### PR DESCRIPTION
## Summary
- compute progressive levels from user points
- show level badge with progress in profile and feed
- link to user profiles from feed and ranking pages

## Testing
- `python -m py_compile taverna/utils.py taverna/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b25a679620832487a476387cdbddb1