### PR TITLE
Improve feed search accessibility and clean CSS layout

### DIFF
--- a/taverna/static/css/style.css
+++ b/taverna/static/css/style.css
@@ -27,6 +27,18 @@ img {
   width: 100%;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .overflow-hidden {
   overflow: hidden;
 }
@@ -488,35 +500,33 @@ img {
 
 .busca-tag {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   justify-content: center;
-  margin: 30px auto 10px;
-  max-width: 600px;
+  margin: 20px auto 30px;
+  max-width: 700px;
   padding: 0 20px;
 }
 
 .input-tag {
-  border-radius: 12px;
+  border-radius: 10px;
   border: 2px solid #ccc;
   flex: 1;
   font-size: 16px;
-  outline: none;
   padding: 10px 14px;
 }
 
 .botao-busca {
-  background-color: #ff5733;
-  border-radius: 12px;
+  background-color: #3a64d8;
+  border-radius: 10px;
   border: none;
   color: white;
   cursor: pointer;
   font-weight: bold;
-  padding: 10px 18px;
-  transition: background 0.3s ease;
+  padding: 10px 20px;
 }
 
 .botao-busca:hover {
-  background-color: #e34d26;
+  background-color: #265edb;
 }
 
 .galeria-feed {
@@ -543,34 +553,6 @@ img {
   object-fit: contain;
   width: 100%;
 }
-
-.busca-tag {
-  display: flex;
-  gap: 10px;
-  justify-content: center;
-  margin: 20px auto 30px;
-  max-width: 700px;
-  padding: 0 20px;
-}
-
-.input-tag {
-  border-radius: 10px;
-  border: 2px solid #ccc;
-  flex: 1;
-  font-size: 16px;
-  padding: 10px 14px;
-}
-
-.botao-busca {
-  background-color: #3a64d8;
-  border-radius: 10px;
-  border: none;
-  color: white;
-  cursor: pointer;
-  font-weight: bold;
-  padding: 10px 20px;
-}
-
 /* Layout em linha */
 .linha-feed {
   display: flex;
@@ -595,10 +577,12 @@ img {
 }
 
 .imagem-feed {
-  border-radius: 10px;
+  border-radius: 12px;
+  width: 100%;
   height: auto;
+  max-height: 180px;
+  object-fit: cover;
   margin-bottom: 10px;
-  max-width: 100%;
 }
 
 .arquivo-generico img {
@@ -1026,13 +1010,6 @@ body {
   background: #fffafc;
 }
 
-.imagem-feed {
-  border-radius: 12px;
-  max-height: 180px;
-  object-fit: cover;
-  width: 100%;
-  margin-bottom: 10px;
-}
 
 .titulo-projeto {
   font-size: 1.2rem;

--- a/taverna/templates/feed.html
+++ b/taverna/templates/feed.html
@@ -13,7 +13,9 @@ Feed da Taverna
 
     <!-- 🔍 Barra de busca com filtros unificados -->
     <form method="GET" action="{{ url_for('feed') }}" class="form-busca-tag">
+      <label for="tag-busca" class="sr-only">Buscar por palavra-chave</label>
       <input
+        id="tag-busca"
         type="text"
         name="tag"
         placeholder="Buscar por palavra-chave"
@@ -115,14 +117,14 @@ Feed da Taverna
             {% set icone = icones.get(extensao, 'lontra-croft.png') %}
 
             {% if extensao in ['jpg', 'jpeg', 'png'] %}
-              <img src="{{ url_for('static', filename='projetos_midias/' ~ f.nome_arquivo) }}" class="imagem-feed">
+              <img src="{{ url_for('static', filename='projetos_midias/' ~ f.nome_arquivo) }}" class="imagem-feed" alt="Mídia do projeto {{ projeto.titulo }}">
             {% elif extensao == 'mp4' %}
               <video controls class="imagem-feed">
                 <source src="{{ url_for('static', filename='projetos_midias/' ~ f.nome_arquivo) }}" type="video/mp4">
               </video>
             {% else %}
               <div class="arquivo-generico">
-                <img src="{{ url_for('static', filename='fotos_site/' ~ icone) }}" class="imagem-feed">
+                <img src="{{ url_for('static', filename='fotos_site/' ~ icone) }}" class="imagem-feed" alt="Arquivo {{ f.nome_arquivo }}">
                 <a href="{{ url_for('static', filename='projetos_midias/' ~ f.nome_arquivo) }}" target="_blank">
                   {{ f.nome_arquivo }}
                 </a>


### PR DESCRIPTION
## Summary
- add hidden label and alt text for feed search and media images
- deduplicate feed CSS styles and include screen-reader utility class

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b2604b4d1483249dec7f0e10e4b73f