### PR TITLE
Enable editing existing projects

### DIFF
--- a/taverna/templates/novo_projeto.html
+++ b/taverna/templates/novo_projeto.html
@@ -1,30 +1,29 @@
 {% extends "homepage.html" %}
 
 {% block titulo %}
-Novo Projeto
+{% if projeto %}Editar Projeto{% else %}Novo Projeto{% endif %}
 {% endblock %}
 
 {% block body %}
 <body>
   {% include "navbar.html" %}
   <section class="container">
-    <h1>Publicar novo projeto</h1>
-    <form method="POST" enctype="multipart/form-data" class="form-projeto">
+    <h1>{% if projeto %}Editar projeto{% else %}Publicar novo projeto{% endif %}</h1>
+    <form method="POST" enctype="multipart/form-data" class="form-projeto" {% if projeto %}action="{{ url_for('editar_projeto', id_projeto=projeto.id) }}"{% endif %}>
       {{ form.csrf_token }}
       {{ form.titulo(placeholder="Título do Projeto", class="input") }}
       {{ form.descricao(placeholder="Descrição", class="input") }}
       {{ form.conteudo(placeholder="Conteúdo adicional", class="input") }}
-      {{ form.categoria(class="input") }}
-      {{ form.ano_escolar(class="input") }}
-      {{ form.tags(placeholder="Tags (mínimo 1)", class="input") }}
-      {{ form.arquivos(class="input-arquivo", multiple=true) }}
-      <div class="div-input">
-  <label class="label" for="arquivos">Upload de Arquivos</label>
-  {{ form.arquivos(class="input", multiple=True) }}
-</div>
+        {{ form.categoria(class="input") }}
+        {{ form.ano_escolar(class="input") }}
+        {{ form.tags(placeholder="Tags (mínimo 1)", class="input") }}
+        <div class="div-input">
+          <label class="label" for="arquivos">Upload de Arquivos</label>
+          {{ form.arquivos(class="input", multiple=True) }}
+        </div>
 
-      {{ form.botao_confirmacao(class="botao-login") }}
-    </form>
+        {{ form.botao_confirmacao('Salvar alterações' if projeto else 'Enviar Projeto', class="botao-login") }}
+      </form>
   </section>
 </body>
 {% endblock %}

--- a/taverna/templates/projects/detail.html
+++ b/taverna/templates/projects/detail.html
@@ -122,17 +122,21 @@
           {% endif %}
         </dl>
 
+        {% if current_user.is_authenticated and current_user.id == project.autor.id %}
         <div class="mt-5 flex gap-2">
-          <a href="{{ url_for('novo_projeto') }}" class="flex-1 rounded-xl border px-3 py-2 text-center hover:bg-gray-50">Editar</a>
+          <a href="{{ url_for('editar_projeto', id_projeto=project.id) }}" class="flex-1 rounded-xl border px-3 py-2 text-center hover:bg-gray-50">Editar</a>
           <button type="button" class="flex-1 rounded-xl bg-rose-600 text-white px-3 py-2 hover:bg-rose-700" data-open="delete-modal">Excluir</button>
         </div>
+        {% endif %}
       </div>
 
       <!-- Action bar sticky (mobile) -->
+      {% if current_user.is_authenticated and current_user.id == project.autor.id %}
       <div class="lg:hidden fixed bottom-0 left-0 right-0 bg-white/90 backdrop-blur border-t p-3 flex gap-2">
-        <a href="{{ url_for('novo_projeto') }}" class="flex-1 rounded-xl border px-3 py-2 text-center">Editar</a>
+        <a href="{{ url_for('editar_projeto', id_projeto=project.id) }}" class="flex-1 rounded-xl border px-3 py-2 text-center">Editar</a>
         <button type="button" class="flex-1 rounded-xl bg-rose-600 text-white px-3 py-2" data-open="delete-modal">Excluir</button>
       </div>
+      {% endif %}
     </aside>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add editar_projeto route to update existing projects and attach new media
- Make project form reusable for editing with dynamic title and submit label
- Link edit buttons to editar_projeto and show only for project authors

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb19b661bc8324b8f2b8f0d9991201