### PR TITLE
Add media carousel for project detail view

### DIFF
--- a/taverna/routes.py
+++ b/taverna/routes.py
@@ -9,6 +9,7 @@ from taverna.models import (
 from flask import render_template, url_for, redirect, request, abort
 from flask_login import login_required, login_user, logout_user, current_user
 import os
+import mimetypes
 from werkzeug.utils import secure_filename
 from sqlalchemy import or_
 
@@ -260,6 +261,18 @@ def editar_projeto(id_projeto):
 def visualizar_projeto(id_projeto):
     projeto = Projeto.query.get_or_404(id_projeto)
     form_comentario = FormComentario()
+
+    projeto.title = projeto.titulo
+    midias = []
+    for m in projeto.midias:
+        caminho = f"projetos_midias/{m.nome_arquivo}"
+        mime_type, _ = mimetypes.guess_type(m.nome_arquivo)
+        midias.append({
+            "filepath": caminho,
+            "mime_type": mime_type,
+            "alt": m.nome_arquivo
+        })
+    projeto.media = midias
 
     if form_comentario.validate_on_submit():
         novo_comentario = ComentarioProjeto(

--- a/taverna/static/css/carousel.css
+++ b/taverna/static/css/carousel.css
@@ -1,0 +1,28 @@
+.ev-carousel{position:relative;background:#fff;border-radius:16px;box-shadow:0 8px 20px rgba(16,24,40,.08);padding:12px}
+.ev-carousel__viewport{overflow:hidden;border-radius:12px}
+.ev-carousel__track{display:flex;gap:12px;will-change:transform;transition:transform .35s ease}
+.ev-carousel__slide{flex:0 0 100%;position:relative}
+.ev-carousel__media{width:100%;height:100%;object-fit:cover;aspect-ratio:16/9;border-radius:12px;display:block}
+.ev-carousel__fallback{display:flex;align-items:center;justify-content:center;min-height:220px;background:#fafafa;border-radius:12px;color:#6b7280}
+.ev-carousel__nav{position:absolute;top:50%;transform:translateY(-50%);width:40px;height:40px;border-radius:999px;border:none;background:rgba(17,24,39,.6);color:#fff;font-size:22px;display:grid;place-items:center;cursor:pointer}
+.ev-carousel__nav:focus{outline:2px solid #6366f1;outline-offset:2px}
+.ev-carousel__nav--prev{left:10px}
+.ev-carousel__nav--next{right:10px}
+.ev-carousel__dots{display:flex;gap:8px;justify-content:center;margin-top:10px}
+.ev-carousel__dot{width:10px;height:10px;border-radius:999px;border:0;background:#e5e7eb;cursor:pointer}
+.ev-carousel__dot[aria-selected="true"]{background:#6366f1}
+
+@media (hover:hover){
+  .ev-carousel__nav:hover{background:rgba(17,24,39,.8)}
+}
+
+.ev-lightbox[hidden]{display:none}
+.ev-lightbox{position:fixed;inset:0;z-index:60;display:grid;place-items:center}
+.ev-lightbox__backdrop{position:absolute;inset:0;background:rgba(0,0,0,.5)}
+.ev-lightbox__content{position:relative;max-width:min(96vw,1100px);width:100%;padding:12px}
+.ev-lightbox__stage{background:#000;border-radius:12px;display:grid;place-items:center;min-height:min(80vh,700px);overflow:hidden}
+.ev-lightbox__stage img, .ev-lightbox__stage video{max-width:100%;max-height:80vh}
+.ev-lightbox__close{position:absolute;top:10px;right:10px;width:40px;height:40px;border-radius:999px;border:0;background:#fff;color:#111827;font-size:22px;cursor:pointer}
+.ev-lightbox__arrow{position:absolute;top:50%;transform:translateY(-50%);width:44px;height:44px;border-radius:999px;border:0;background:rgba(255,255,255,.9);cursor:pointer}
+.ev-lightbox__arrow--prev{left:8px}
+.ev-lightbox__arrow--next{right:8px}

--- a/taverna/static/js/carousel.js
+++ b/taverna/static/js/carousel.js
@@ -1,0 +1,103 @@
+(function(){
+  function EvCarousel(root){
+    this.root = root.closest('.ev-carousel');
+    this.track = root.querySelector('.ev-carousel__track');
+    this.slides = Array.from(root.querySelectorAll('.ev-carousel__slide'));
+    this.prevBtn = this.root.querySelector('[data-ev-prev]');
+    this.nextBtn = this.root.querySelector('[data-ev-next]');
+    this.dotsWrap = this.root.querySelector('.ev-carousel__dots');
+    this.dots = Array.from(this.root.querySelectorAll('[data-ev-dot]'));
+    this.index = 0;
+    this.count = this.slides.length;
+    this.x = 0; this.startX = 0; this.delta = 0; this.dragging = false;
+    this.init();
+  }
+  EvCarousel.prototype.init = function(){
+    if(this.count <= 1){
+      this.prevBtn?.classList.add('hidden');
+      this.nextBtn?.classList.add('hidden');
+      this.dotsWrap?.classList.add('hidden');
+    }
+    this.update();
+    this.prevBtn?.addEventListener('click', ()=> this.go(this.index-1));
+    this.nextBtn?.addEventListener('click', ()=> this.go(this.index+1));
+    this.dots.forEach(d => d.addEventListener('click', ()=> this.go(parseInt(d.dataset.evDot))));
+    // teclado
+    this.root.addEventListener('keydown', (e)=>{
+      if(e.key==='ArrowLeft'){ this.go(this.index-1); }
+      if(e.key==='ArrowRight'){ this.go(this.index+1); }
+      if(e.key==='Escape'){ closeLightbox(); }
+    });
+    // swipe
+    const viewport = this.root.querySelector('.ev-carousel__viewport');
+    viewport.addEventListener('touchstart', (e)=>{ this.startX = e.touches[0].clientX; this.dragging = true; }, {passive:true});
+    viewport.addEventListener('touchmove', (e)=>{ if(!this.dragging) return; this.delta = e.touches[0].clientX - this.startX; }, {passive:true});
+    viewport.addEventListener('touchend', ()=>{
+      if(!this.dragging) return; this.dragging=false;
+      if(this.delta > 40) this.go(this.index-1);
+      else if(this.delta < -40) this.go(this.index+1);
+      this.delta = 0;
+    });
+    // lightbox open
+    this.slides.forEach((s,i)=>{
+      s.addEventListener('click', ()=>{
+        openLightbox(this, i);
+      });
+    });
+  };
+  EvCarousel.prototype.go = function(i){
+    if(this.count===0) return;
+    this.index = (i + this.count) % this.count;
+    this.update();
+  };
+  EvCarousel.prototype.update = function(){
+    const offset = this.index * -100;
+    this.track.style.transform = `translateX(${offset}%)`;
+    this.dots.forEach((d,idx)=> d.setAttribute('aria-selected', idx===this.index ? 'true' : 'false'));
+  };
+
+  // Lightbox
+  const lb = document.getElementById('ev-lightbox');
+  const lbStage = lb?.querySelector('.ev-lightbox__stage');
+  let lbCarousel = null;
+
+  function openLightbox(carousel, index){
+    if(!lb || !lbStage) return;
+    lbCarousel = carousel;
+    lb.removeAttribute('hidden');
+    renderLB(index);
+  }
+  function closeLightbox(){
+    if(!lb) return;
+    lb.setAttribute('hidden','');
+    lbStage.innerHTML='';
+    lbCarousel = null;
+  }
+  function renderLB(index){
+    if(!lbCarousel) return;
+    lbCarousel.index = index;
+    lbCarousel.update();
+    const slide = lbCarousel.slides[index];
+    const media = slide.querySelector('img,video');
+    lbStage.innerHTML = '';
+    if(media.tagName.toLowerCase()==='img'){
+      const img = document.createElement('img');
+      img.src = media.currentSrc || media.src;
+      img.alt = media.alt || '';
+      lbStage.appendChild(img);
+    }else{
+      const v = document.createElement('video');
+      v.controls = true;
+      v.src = media.querySelector('source')?.src || media.src;
+      lbStage.appendChild(v);
+    }
+  }
+  document.querySelectorAll('[data-ev-close]').forEach(b=> b.addEventListener('click', closeLightbox));
+  document.querySelector('[data-ev-lb-prev]')?.addEventListener('click', ()=> renderLB((lbCarousel.index-1+lbCarousel.count)%lbCarousel.count));
+  document.querySelector('[data-ev-lb-next]')?.addEventListener('click', ()=> renderLB((lbCarousel.index+1)%lbCarousel.count));
+  lb?.addEventListener('click', (e)=>{ if(e.target.classList.contains('ev-lightbox__backdrop')) closeLightbox(); });
+  window.addEventListener('keydown', (e)=>{ if(e.key==='Escape') closeLightbox(); });
+
+  // boot
+  document.querySelectorAll('[data-ev-carousel]').forEach(vp => new EvCarousel(vp));
+})();

--- a/taverna/templates/homepage.html
+++ b/taverna/templates/homepage.html
@@ -10,7 +10,10 @@
   </title>
 
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/carousel.css') }}">
   <link rel="icon" href="{{ url_for('static', filename='favicon.png') }}" type="image/png">
+
+  <script defer src="{{ url_for('static', filename='js/carousel.js') }}"></script>
 
 
 </head>

--- a/taverna/templates/partials/carousel.html
+++ b/taverna/templates/partials/carousel.html
@@ -1,0 +1,45 @@
+{% set _title = project.title or 'Galeria do projeto' %}
+<div class="ev-carousel" role="region" aria-roledescription="carousel" aria-label="Galeria: {{ _title }}">
+  <div class="ev-carousel__viewport" data-ev-carousel>
+    <ul class="ev-carousel__track">
+      {% for m in project.media %}
+      <li class="ev-carousel__slide" data-index="{{ loop.index0 }}">
+        {% set src = url_for('static', filename=m.filepath) if m.filepath and not m.filepath.startswith('http') else m.filepath %}
+        {% if m.mime_type and m.mime_type.startswith('video/') %}
+          <video class="ev-carousel__media" controls preload="metadata" aria-label="{{ m.alt or ('Vídeo - ' ~ _title) }}">
+            <source src="{{ src }}" type="{{ m.mime_type }}">
+            Seu navegador não suporta vídeo. <a href="{{ src }}" target="_blank" rel="noopener">Abrir vídeo</a>
+          </video>
+        {% elif m.mime_type and m.mime_type.startswith('image/') or (not m.mime_type) %}
+          <img class="ev-carousel__media" src="{{ src }}" alt="{{ m.alt or ('Imagem do projeto ' ~ _title) }}" loading="lazy" decoding="async">
+        {% else %}
+          <div class="ev-carousel__fallback">
+            Arquivo não visualizável. <a href="{{ src }}" target="_blank" rel="noopener">Abrir arquivo</a>
+          </div>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <!-- Controles (escondidos via JS/CSS se só houver 1 item) -->
+  <button class="ev-carousel__nav ev-carousel__nav--prev" type="button" aria-label="Slide anterior" data-ev-prev>&lsaquo;</button>
+  <button class="ev-carousel__nav ev-carousel__nav--next" type="button" aria-label="Próximo slide" data-ev-next>&rsaquo;</button>
+
+  <div class="ev-carousel__dots" role="tablist" aria-label="Indicadores de slides">
+    {% for m in project.media %}
+    <button class="ev-carousel__dot" role="tab" aria-label="Ir para slide {{ loop.index }}" aria-controls="slide-{{ loop.index }}" data-ev-dot="{{ loop.index0 }}"></button>
+    {% endfor %}
+  </div>
+</div>
+
+<!-- Modal/lightbox -->
+<div class="ev-lightbox" id="ev-lightbox" hidden aria-modal="true" role="dialog" aria-label="Visualização ampliada">
+  <div class="ev-lightbox__backdrop" data-ev-close></div>
+  <div class="ev-lightbox__content">
+    <button class="ev-lightbox__close" type="button" aria-label="Fechar" data-ev-close>×</button>
+    <button class="ev-lightbox__arrow ev-lightbox__arrow--prev" type="button" aria-label="Anterior" data-ev-lb-prev>&lsaquo;</button>
+    <div class="ev-lightbox__stage"></div>
+    <button class="ev-lightbox__arrow ev-lightbox__arrow--next" type="button" aria-label="Próximo" data-ev-lb-next>&rsaquo;</button>
+  </div>
+</div>

--- a/taverna/templates/projects/detail.html
+++ b/taverna/templates/projects/detail.html
@@ -23,44 +23,8 @@
     <!-- Coluna Conteúdo (lg:2) -->
     <section class="lg:col-span-2 space-y-6">
       <!-- Galeria -->
-      {% if project.midias %}
-      <div class="bg-white rounded-2xl shadow p-4">
-        <ul class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {% for m in project.midias %}
-          {% set ext = m.nome_arquivo.split('.')[-1].lower() %}
-          {% set icones = {
-            'pdf': 'lontra-pdf.png',
-            'doc': 'lontra-docx.png',
-            'docx': 'lontra-docx.png',
-            'ppt': 'lontra-croft.png',
-            'pptx': 'lontra-croft.png',
-            'csv': 'lontra-csv.png',
-            'xlsx': 'lontra-xlsx.png'
-          } %}
-          {% if ext in ['jpg', 'jpeg', 'png'] %}
-          <li>
-            <button type="button" class="group w-full rounded-xl overflow-hidden shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" data-modal-image="{{ url_for('static', filename='projetos_midias/' ~ m.nome_arquivo) }}" aria-label="Ver mídia">
-              <img src="{{ url_for('static', filename='projetos_midias/' ~ m.nome_arquivo) }}" alt="Mídia do projeto" class="w-full h-52 object-cover group-hover:scale-[1.02] transition-all">
-            </button>
-          </li>
-          {% elif ext == 'mp4' %}
-          <li>
-            <video controls class="w-full h-52 object-cover rounded-xl">
-              <source src="{{ url_for('static', filename='projetos_midias/' ~ m.nome_arquivo) }}" type="video/mp4">
-            </video>
-          </li>
-          {% else %}
-          {% set icone = icones.get(ext, 'lontra-croft.png') %}
-          <li>
-            <div class="flex flex-col items-center justify-center p-4 border rounded-xl">
-              <img src="{{ url_for('static', filename='fotos_site/' ~ icone) }}" class="w-20 h-20 object-contain mb-2" alt="Arquivo {{ m.nome_arquivo }}">
-              <a href="{{ url_for('static', filename='projetos_midias/' ~ m.nome_arquivo) }}" target="_blank" class="text-sm text-indigo-600 hover:underline">{{ m.nome_arquivo }}</a>
-            </div>
-          </li>
-          {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
+      {% if project.media and project.media|length > 0 %}
+        {% include "partials/carousel.html" %}
       {% endif %}
 
       <!-- Descrição/Conteúdo -->


### PR DESCRIPTION
## Summary
- Replace static media grid with reusable carousel partial
- Add responsive carousel styles and interactive controls
- Prepare project media metadata in view and load carousel assets globally

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb38c1ab808324906e5e92cd012b70