### PR TITLE
Handle empty uploads in project form

### DIFF
--- a/taverna/forms.py
+++ b/taverna/forms.py
@@ -5,7 +5,7 @@ from flask_wtf.file import FileField, FileAllowed
 from wtforms import (
     StringField, PasswordField, SubmitField, TextAreaField, MultipleFileField, RadioField
 )
-from wtforms.validators import DataRequired, Email, EqualTo, Length, ValidationError
+from wtforms.validators import DataRequired, Email, EqualTo, Length, ValidationError, Optional
 from taverna.models import Usuario
 
 # ---------- Formulário de Login ----------
@@ -98,9 +98,20 @@ class FormProjeto(FlaskForm):
     
     tags = StringField("Tags (mínimo 1)", validators=[DataRequired(), Length(min=2)])
 
-    arquivos = MultipleFileField("Arquivos", validators=[
-    FileAllowed(['jpg', 'jpeg', 'png', 'mp4', 'pdf', 'doc', 'docx', 'ppt', 'pptx'], "Tipos permitidos.")
-])
+    arquivos = MultipleFileField(
+        "Arquivos",
+        validators=[
+            Optional(),
+            FileAllowed(
+                ['jpg', 'jpeg', 'png', 'mp4', 'pdf', 'doc', 'docx', 'ppt', 'pptx'],
+                "Tipos permitidos."
+            )
+        ],
+    )
+
+    def validate_arquivos(self, field):
+        # Remove entradas vazias para evitar falha de validação
+        field.data = [f for f in field.data if f and getattr(f, "filename", "")]
     
     botao_confirmacao = SubmitField("Enviar Projeto")
 


### PR DESCRIPTION
## Summary
- Allow submitting project without files
- Clean file list to avoid validation errors when no files are selected

## Testing
- `python -m py_compile taverna/forms.py`
- `python - <<'PY'
from taverna import app, database, bcrypt
from taverna.models import Usuario, Projeto
import re

with app.app_context():
    u = Usuario.query.filter_by(email='user4@example.com').first()
    if not u:
        u = Usuario(username='user4', email='user4@example.com', senha=bcrypt.generate_password_hash('123456'))
        database.session.add(u)
        database.session.commit()

with app.test_client() as client:
    resp = client.get('/')
    token = re.search(r'name="csrf_token" type="hidden" value="([^"]+)"', resp.data.decode('utf-8')).group(1)
    client.post('/', data={'csrf_token': token, 'email':'user4@example.com','senha':'123456','botao_confirmacao':'Entrar na Taverna'}, follow_redirects=True)
    resp = client.get('/novo_projeto')
    token = re.search(r'name="csrf_token" type="hidden" value="([^"]+)"', resp.data.decode('utf-8')).group(1)
    data={'csrf_token': token, 'titulo':'PnoFile','descricao':'desc','conteudo':'cont','categoria':'artes','ano_escolar':'1o_ano','tags':'tag1','botao_confirmacao':'Enviar Projeto'}
    resp2 = client.post('/novo_projeto', data=data, follow_redirects=True)
    print('status', resp2.status_code)
    with app.app_context():
        p = Projeto.query.filter_by(titulo='PnoFile').first()
        print('project', p.id if p else None)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b065e0083249b82f3048876e125