### PR TITLE
Exibir ícones para arquivos não visuais no projeto

### DIFF
--- a/taverna/static/css/carousel.css
+++ b/taverna/static/css/carousel.css
@@ -3,7 +3,7 @@
 .ev-carousel__track{display:flex;gap:12px;will-change:transform;transition:transform .35s ease}
 .ev-carousel__slide{flex:0 0 100%;position:relative}
 .ev-carousel__media{width:100%;height:100%;object-fit:cover;aspect-ratio:16/9;border-radius:12px;display:block}
-.ev-carousel__fallback{display:flex;align-items:center;justify-content:center;min-height:220px;background:#fafafa;border-radius:12px;color:#6b7280}
+.ev-carousel__fallback{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;min-height:220px;padding:16px;text-align:center;background:#fafafa;border-radius:12px;color:#6b7280}
 .ev-carousel__nav{position:absolute;top:50%;transform:translateY(-50%);width:40px;height:40px;border-radius:999px;border:none;background:rgba(17,24,39,.6);color:#fff;font-size:22px;display:grid;place-items:center;cursor:pointer}
 .ev-carousel__nav:focus{outline:2px solid #6366f1;outline-offset:2px}
 .ev-carousel__nav--prev{left:10px}

--- a/taverna/templates/partials/carousel.html
+++ b/taverna/templates/partials/carousel.html
@@ -13,8 +13,20 @@
         {% elif m.mime_type and m.mime_type.startswith('image/') or (not m.mime_type) %}
           <img class="ev-carousel__media" src="{{ src }}" alt="{{ m.alt or ('Imagem do projeto ' ~ _title) }}" loading="lazy" decoding="async">
         {% else %}
+          {% set ext = (m.alt or '').split('.')[-1].lower() %}
+          {% set icons = {
+            'pdf': 'lontra-pdf.png',
+            'doc': 'lontra-docx.png',
+            'docx': 'lontra-docx.png',
+            'ppt': 'lontra-croft.png',
+            'pptx': 'lontra-croft.png',
+            'csv': 'lontra-csv.png',
+            'xlsx': 'lontra-xlsx.png'
+          } %}
+          {% set icon = icons.get(ext, 'lontra-croft.png') %}
           <div class="ev-carousel__fallback">
-            Arquivo não visualizável. <a href="{{ src }}" target="_blank" rel="noopener">Abrir arquivo</a>
+            <img src="{{ url_for('static', filename='fotos_site/' ~ icon) }}" alt="Arquivo {{ m.alt }}" class="w-20 h-20 object-contain mb-2">
+            <a href="{{ src }}" target="_blank" rel="noopener" class="text-indigo-600 hover:underline">{{ m.alt }}</a>
           </div>
         {% endif %}
       </li>


### PR DESCRIPTION
## Summary
- Mostrar ícones específicos para PDFs, DOCs e outros arquivos na galeria do projeto
- Ajustar layout da área de fallback do carrossel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3dcb34908324877bc0b1f994a4b2