### PR TITLE
Fix media filtering for project view

### DIFF
--- a/taverna/routes.py
+++ b/taverna/routes.py
@@ -274,6 +274,27 @@ def visualizar_projeto(id_projeto):
         })
     projeto.media = midias
 
+    visual_media = [
+        m
+        for m in projeto.media
+        if m.get("mime_type")
+        and (
+            m["mime_type"].startswith("image/")
+            or m["mime_type"].startswith("video/")
+        )
+    ]
+    attachments = [
+        m
+        for m in projeto.media
+        if not (
+            m.get("mime_type")
+            and (
+                m["mime_type"].startswith("image/")
+                or m["mime_type"].startswith("video/")
+            )
+        )
+    ]
+
     if form_comentario.validate_on_submit():
         novo_comentario = ComentarioProjeto(
             texto=form_comentario.texto.data,
@@ -292,7 +313,9 @@ def visualizar_projeto(id_projeto):
         "visualizar_projeto.html",
         project=projeto,
         comments=projeto.comentarios,
-        form=form_comentario
+        form=form_comentario,
+        visual_media=visual_media,
+        attachments=attachments,
     )
 
 

--- a/taverna/templates/visualizar_projeto.html
+++ b/taverna/templates/visualizar_projeto.html
@@ -43,13 +43,11 @@
     <section class="lg:col-span-2 space-y-6">
 
       {# MÍDIA VISUAL #}
-      {% set visual_media = [m for m in project.media if (m.mime_type and (m.mime_type.startswith('image/') or m.mime_type.startswith('video/'))) ] %}
       {% if visual_media|length > 0 %}
         {% include 'partials/carousel.html' %}
       {% endif %}
 
       {# ANEXOS (NÃO-IMAGEM) #}
-      {% set attachments = [m for m in project.media if (not m.mime_type) or (not (m.mime_type.startswith('image/') or m.mime_type.startswith('video/'))) ] %}
       {% if attachments|length > 0 %}
         {% include 'partials/attachments.html' %}
       {% endif %}


### PR DESCRIPTION
## Summary
- Build visual media and attachment lists in `visualizar_projeto` route
- Use precomputed lists in `visualizar_projeto.html` to avoid Jinja syntax errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb41dc8e148324a79e2aaf053a0aef