### PR TITLE
Support spreadsheet attachments

### DIFF
--- a/taverna/forms.py
+++ b/taverna/forms.py
@@ -46,8 +46,8 @@ class FormCriarConta(FlaskForm):
 class FormFoto(FlaskForm):
     foto = FileField("Arquivo", validators=[
         DataRequired(),
-        FileAllowed(['jpg', 'png', 'pdf', 'docx', 'pptx', 'mp4'], 
-                    "Formatos permitidos: .jpg, .png, .pdf, .docx, .pptx, .mp4")
+        FileAllowed(['jpg', 'png', 'pdf', 'docx', 'pptx', 'mp4', 'csv', 'xlsx'],
+                    "Formatos permitidos: .jpg, .png, .pdf, .docx, .pptx, .mp4, .csv, .xlsx")
     ])
     tags = StringField("Tags (separadas por vírgula)")
     botao_confirmacao = SubmitField("Enviar")
@@ -103,7 +103,7 @@ class FormProjeto(FlaskForm):
         validators=[
             Optional(),
             FileAllowed(
-                ['jpg', 'jpeg', 'png', 'mp4', 'pdf', 'doc', 'docx', 'ppt', 'pptx'],
+                ['jpg', 'jpeg', 'png', 'mp4', 'pdf', 'doc', 'docx', 'ppt', 'pptx', 'csv', 'xlsx'],
                 "Tipos permitidos."
             )
         ],

--- a/taverna/templates/partials/attachments.html
+++ b/taverna/templates/partials/attachments.html
@@ -21,7 +21,7 @@
           <div class="truncate font-medium text-gray-900" title="{{ filename }}">{{ filename }}</div>
           <div class="text-xs text-gray-500">{{ a.mime_type or 'arquivo' }}{% if a.size_kb %} • {{ a.size_kb }} KB{% endif %}</div>
         </div>
-        <a href="{{ href }}" target="_blank" rel="noopener" class="rounded-xl border px-3 py-1.5 text-sm hover:bg-gray-50">Abrir</a>
+        <a href="{{ href }}" target="_blank" rel="noopener" download class="rounded-xl border px-3 py-1.5 text-sm hover:bg-gray-50">Abrir</a>
       </li>
     {% endfor %}
   </ul>

--- a/taverna/templates/partials/carousel.html
+++ b/taverna/templates/partials/carousel.html
@@ -27,7 +27,7 @@
           {% set icon = icons.get(ext, 'lontra-croft.png') %}
           <div class="ev-carousel__fallback">
             <img src="{{ url_for('static', filename='fotos_site/' ~ icon) }}" alt="Arquivo {{ m.alt }}" class="w-20 h-20 object-contain mb-2">
-            <a href="{{ src }}" target="_blank" rel="noopener" class="text-indigo-600 hover:underline">{{ m.alt }}</a>
+            <a href="{{ src }}" target="_blank" rel="noopener" download class="text-indigo-600 hover:underline">{{ m.alt }}</a>
           </div>
         {% endif %}
       </li>


### PR DESCRIPTION
## Summary
- allow csv and xlsx uploads in project and photo forms
- ensure carousel and attachment links download non-visual files using spreadsheet icons

## Testing
- `python -m py_compile taverna/forms.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c756dcf7f48324a4bd5f15b28c8115