### PR TITLE
Add mp3/wav upload and playback support

### DIFF
--- a/taverna/forms.py
+++ b/taverna/forms.py
@@ -46,8 +46,8 @@ class FormCriarConta(FlaskForm):
 class FormFoto(FlaskForm):
     foto = FileField("Arquivo", validators=[
         DataRequired(),
-        FileAllowed(['jpg', 'png', 'pdf', 'docx', 'pptx', 'mp4', 'csv', 'xlsx'],
-                    "Formatos permitidos: .jpg, .png, .pdf, .docx, .pptx, .mp4, .csv, .xlsx")
+        FileAllowed(['jpg', 'png', 'pdf', 'docx', 'pptx', 'mp4', 'csv', 'xlsx', 'mp3', 'wav'],
+                    "Formatos permitidos: .jpg, .png, .pdf, .docx, .pptx, .mp4, .csv, .xlsx, .mp3, .wav")
     ])
     tags = StringField("Tags (separadas por vírgula)")
     botao_confirmacao = SubmitField("Enviar")
@@ -103,7 +103,7 @@ class FormProjeto(FlaskForm):
         validators=[
             Optional(),
             FileAllowed(
-                ['jpg', 'jpeg', 'png', 'mp4', 'pdf', 'doc', 'docx', 'ppt', 'pptx', 'csv', 'xlsx'],
+                ['jpg', 'jpeg', 'png', 'mp4', 'pdf', 'doc', 'docx', 'ppt', 'pptx', 'csv', 'xlsx', 'mp3', 'wav'],
                 "Tipos permitidos."
             )
         ],

--- a/taverna/templates/partials/attachments.html
+++ b/taverna/templates/partials/attachments.html
@@ -7,7 +7,9 @@
     'ppt': 'lontra-croft.png',
     'pptx': 'lontra-croft.png',
     'csv': 'lontra-csv.png',
-    'xlsx': 'lontra-xlsx.png'
+    'xlsx': 'lontra-xlsx.png',
+    'mp3': 'lontra-croft.png',
+    'wav': 'lontra-croft.png'
   } %}
   <ul class="divide-y">
     {% for a in attachments %}

--- a/taverna/templates/partials/carousel.html
+++ b/taverna/templates/partials/carousel.html
@@ -13,6 +13,11 @@
           </video>
         {% elif m.mime_type and m.mime_type.startswith('image/') or (not m.mime_type) %}
           <img class="ev-carousel__media" src="{{ src }}" alt="{{ m.alt or ('Imagem do projeto ' ~ _title) }}" loading="lazy" decoding="async">
+        {% elif m.mime_type and m.mime_type.startswith('audio/') %}
+          <audio class="ev-carousel__media" controls preload="metadata" aria-label="{{ m.alt or ('Áudio - ' ~ _title) }}">
+            <source src="{{ src }}" type="{{ m.mime_type }}">
+            Seu navegador não suporta áudio. <a href="{{ src }}" target="_blank" rel="noopener">Ouvir áudio</a>
+          </audio>
         {% else %}
           {% set ext = (m.alt or '').split('.')[-1].lower() %}
           {% set icons = {

--- a/taverna/templates/visualizar_projeto.html
+++ b/taverna/templates/visualizar_projeto.html
@@ -47,8 +47,36 @@
         {% include 'partials/carousel.html' %}
       {% endif %}
 
-      {# ANEXOS (NÃO-IMAGEM) #}
-      {% if attachments|length > 0 %}
+      {# ÁUDIOS E ANEXOS #}
+      {% set ns = namespace(audios=[], outros=[]) %}
+      {% for a in attachments %}
+        {% if a.mime_type and a.mime_type.startswith('audio/') %}
+          {% set _ = ns.audios.append(a) %}
+        {% else %}
+          {% set _ = ns.outros.append(a) %}
+        {% endif %}
+      {% endfor %}
+
+      {% if ns.audios %}
+        <section class="bg-white rounded-2xl shadow p-6">
+          <h2 class="text-lg font-semibold mb-3">Áudios</h2>
+          <ul class="space-y-4">
+            {% for a in ns.audios %}
+              {% set src = url_for('static', filename=a.filepath) if a.filepath and not a.filepath.startswith('http') else a.filepath %}
+              <li>
+                <audio controls class="w-full">
+                  <source src="{{ src }}" type="{{ a.mime_type }}">
+                  Seu navegador não suporta áudio. <a href="{{ src }}" target="_blank" rel="noopener">Ouvir áudio</a>
+                </audio>
+                <div class="text-xs text-gray-500 mt-1">{{ a.original_name or a.alt }}</div>
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+
+      {% if ns.outros %}
+        {% set attachments = ns.outros %}
         {% include 'partials/attachments.html' %}
       {% endif %}
 


### PR DESCRIPTION
## Summary
- Allow mp3 and wav files in upload forms
- Render mp3/wav media with `<audio>` in project carousel and viewer
- Show mp3/wav icons in attachment listings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c758c6d1d4832489f0dbd0591b87a8