### PR TITLE
Order feed by like count and expose likes

### DIFF
--- a/taverna/routes.py
+++ b/taverna/routes.py
@@ -160,9 +160,17 @@ def feed():
     if sort == 'old':
         query = query.order_by(Projeto.data_criacao.asc())
     elif sort == 'comments':
-        query = query.outerjoin(ComentarioProjeto).group_by(Projeto.id).order_by(func.count(ComentarioProjeto.id).desc())
+        query = (
+            query.outerjoin(ComentarioProjeto)
+            .group_by(Projeto.id)
+            .order_by(func.count(ComentarioProjeto.id).desc())
+        )
     elif sort == 'rating':
-        query = query.order_by(Projeto.data_criacao.desc())
+        query = (
+            query.outerjoin(Curtida)
+            .group_by(Projeto.id)
+            .order_by(func.count(Curtida.id).desc())
+        )
     else:
         query = query.order_by(Projeto.data_criacao.desc())
 
@@ -183,6 +191,7 @@ def feed():
             'grade_year_label': p.ano_escolar,
             'tags': tags_list,
             'media': media,
+            'like_count': len(p.curtidas),
         })
 
     return render_template(


### PR DESCRIPTION
## Summary
- order feed by number of likes when sorting by rating
- expose like count on each project returned to the feed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c75fbfefec8324aed8a0c549e31bd9