### PR TITLE
Add boot script for persistent instance and migration upgrade

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copie para ".env" e ajuste os valores.
+# Caminho PERSISTENTE onde ficará a pasta "instance/" (para o SQLite e uploads).
+# Em produção (Render/Railway), crie um volume e aponte para ele.
+INSTANCE_PATH=/var/data/instance
+
+# Flask
+FLASK_ENV=production
+SECRET_KEY=troque-esta-chave-secreta-super-aleatoria
+
+# Porta: a maioria dos PaaS injeta $PORT automaticamente para o Gunicorn via Procfile/boot.sh
+# PORT=8000

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -w 2 -k gthread -b 0.0.0.0:$PORT main:app
+web: sh boot.sh

--- a/boot.sh
+++ b/boot.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eu
+
+echo "[boot] Iniciando boot do EdVenturers..."
+
+# 1) Carregar .env se existir (sem erro se não existir)
+if [ -f ".env" ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+# 2) Diretório persistente para a 'instance/'
+INSTANCE_PATH="${INSTANCE_PATH:-/var/data/instance}"
+echo "[boot] INSTANCE_PATH='${INSTANCE_PATH}'"
+
+# 3) Garantir pasta persistente e symlink local ./instance -> $INSTANCE_PATH
+mkdir -p "${INSTANCE_PATH}"
+if [ -d "instance" ] && [ ! -L "instance" ]; then
+  echo "[boot] Migrando conteúdo existente de ./instance para ${INSTANCE_PATH}..."
+  cp -a instance/. "${INSTANCE_PATH}/" 2>/dev/null || true
+  rm -rf "instance"
+fi
+if [ -L "instance" ] || [ -e "instance" ]; then
+  rm -rf "instance"
+fi
+ln -s "${INSTANCE_PATH}" "instance"
+echo "[boot] Symlink criado: ./instance -> ${INSTANCE_PATH}"
+
+# 4) Ambiente de produção
+export FLASK_ENV="${FLASK_ENV:-production}"
+export PYTHONUNBUFFERED=1
+
+# 5) Rodar upgrade de banco (idempotente)
+if [ -f "upgrade_banco.py" ]; then
+  echo "[boot] Executando upgrade_banco.py..."
+  python upgrade_banco.py || echo "[boot] Aviso: upgrade_banco.py retornou código de erro, seguindo assim mesmo."
+else
+  echo "[boot] upgrade_banco.py não encontrado; seguindo sem upgrade."
+fi
+
+# 6) Subir Gunicorn
+# Observação: $PORT costuma ser injetado pelo PaaS; usa 8000 localmente se não existir.
+PORT="${PORT:-8000}"
+echo "[boot] Subindo Gunicorn na porta ${PORT}..."
+exec gunicorn -w 2 -k gthread -b 0.0.0.0:"${PORT}" main:app


### PR DESCRIPTION
## Summary
- add an example environment file documenting the persistent instance path
- introduce a boot script that prepares the instance directory, runs migrations, and launches gunicorn
- update the Procfile to start the app through the new boot script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0217b0c5483248addc2d4a713d31d